### PR TITLE
Add github-copilot-notify extension

### DIFF
--- a/extensions/github-copilot-notify/README.md
+++ b/extensions/github-copilot-notify/README.md
@@ -1,0 +1,10 @@
+# GitHub Copilot Notify
+
+This extension shows a native system notification when a Copilot Chat participant finishes responding or when manual interaction is required. It wraps the chat participant creation API to display messages using the operating system's notification center via the [`node-notifier`](https://www.npmjs.com/package/node-notifier) package.
+
+## Building
+
+1. Install dependencies with `npm install`.
+2. Run `npm run compile` to generate the compiled extension in the `dist` folder.
+
+The extension is OS agnostic and works on macOS and Windows.

--- a/extensions/github-copilot-notify/package.json
+++ b/extensions/github-copilot-notify/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "github-copilot-notify",
+  "displayName": "GitHub Copilot Notify",
+  "description": "Shows native notifications when Copilot Chat finishes or requires input",
+  "version": "0.0.1",
+  "publisher": "github",
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": ["Other"],
+  "activationEvents": ["*"] ,
+  "main": "./dist/extension.js",
+  "contributes": {},
+  "scripts": {
+    "compile": "tsc -p ./tsconfig.json"
+  },
+  "devDependencies": {
+    "@types/node": "*",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "node-notifier": "^10.0.1"
+  }
+}

--- a/extensions/github-copilot-notify/src/extension.ts
+++ b/extensions/github-copilot-notify/src/extension.ts
@@ -1,0 +1,38 @@
+import * as vscode from 'vscode';
+import notifier from 'node-notifier';
+
+export function activate(context: vscode.ExtensionContext) {
+    const chat = (vscode as any).chat;
+    if (!chat || !chat.createChatParticipant) {
+        return;
+    }
+
+    const originalCreate = chat.createChatParticipant.bind(chat);
+    chat.createChatParticipant = function(id: string, handler: any) {
+        const wrappedHandler = async (request: any, context: any, response: any, token: vscode.CancellationToken) => {
+            try {
+                const result = await handler(request, context, response, token);
+                notifier.notify({ title: 'GitHub Copilot', message: `Response from ${id} ready` });
+                return result;
+            } catch (err) {
+                throw err;
+            }
+        };
+        const participant = originalCreate(id, wrappedHandler);
+        if (participant.onDidChangePauseState) {
+            participant.onDidChangePauseState((e: any) => {
+                if (e.isPaused) {
+                    notifier.notify({ title: 'GitHub Copilot', message: `Action required for ${id}` });
+                }
+            });
+        }
+        return participant;
+    };
+
+    const copilotChat = vscode.extensions.getExtension('GitHub.copilot-chat');
+    copilotChat?.activate();
+
+    context.subscriptions.push({ dispose: () => { chat.createChatParticipant = originalCreate; } });
+}
+
+export function deactivate() {}

--- a/extensions/github-copilot-notify/src/types.d.ts
+++ b/extensions/github-copilot-notify/src/types.d.ts
@@ -1,0 +1,1 @@
+declare module 'node-notifier';

--- a/extensions/github-copilot-notify/tsconfig.json
+++ b/extensions/github-copilot-notify/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node", "vscode"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add new extension `github-copilot-notify`
- intercept creation of chat participants and show OS notifications when a response finishes or interaction is required

## Testing
- `npm test` *(fails: npm-run-all not found)*

------
https://chatgpt.com/codex/tasks/task_e_686543eb1640833286a8ceecfc4bcf8f